### PR TITLE
【clients】headerとfooterの領域確保&React.lazy導入

### DIFF
--- a/clients/src/components/App.tsx
+++ b/clients/src/components/App.tsx
@@ -1,19 +1,25 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 import { Route, Switch } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import { ConnectedRouter } from 'connected-react-router';
 import { history, store } from '@/store/configureStore';
+import Header from '@/components/Organism/Header';
+import Footer from '@/components/Organism/Footer';
 
 // Components
-import Top from '@/components/Pages/Top';
+const Top = React.lazy(() => import('@/components/Pages/Top'));
 
 const App: React.FC = () => {
   return (
     <Provider store={store}>
       <ConnectedRouter history={history}>
-        <Switch>
-          <Route exact path="/" component={Top} />
-        </Switch>
+        <Header />
+        <Suspense fallback={<div>loading...</div>}>
+          <Switch>
+            <Route exact path="/" component={Top} />
+          </Switch>
+        </Suspense>
+        <Footer />
       </ConnectedRouter>
     </Provider>
   );

--- a/clients/src/components/Organism/Footer.tsx
+++ b/clients/src/components/Organism/Footer.tsx
@@ -1,0 +1,19 @@
+/** @jsx jsx */
+import React from 'react';
+import { jsx } from '@emotion/core';
+import styled from '@emotion/styled';
+
+const FooterStyle = styled.footer`
+  width: 100%;
+  max-height: 28px;
+  text-align: center;
+`;
+
+const Footer: React.FC = () => {
+  const today = new Date();
+  const year = today.getFullYear();
+
+  return <FooterStyle>Copyright © {year} Yusuke Murakami All Rights Reserved.</FooterStyle>;
+};
+
+export default Footer;

--- a/clients/src/components/Organism/Header.tsx
+++ b/clients/src/components/Organism/Header.tsx
@@ -1,0 +1,34 @@
+/** @jsx jsx */
+import React from 'react';
+import { jsx } from '@emotion/core';
+import styled from '@emotion/styled';
+
+const HeaderStyle = styled.header`
+  min-width: 980px;
+  margin: 0 auto;
+  height: 50px;
+  display: flex;
+`;
+
+// 今後firebaseログアウト処理をいれる
+const LoginLink = styled.span`
+  color: blue;
+  margin: 0 0 0 auto;
+`;
+
+const Header: React.FC = () => {
+  const TitleLogo = styled.div`
+    width: 500px;
+    height: 40px;
+    background-color: blue;
+  `;
+
+  return (
+    <HeaderStyle>
+      <TitleLogo />
+      <LoginLink>ログイン</LoginLink>
+    </HeaderStyle>
+  );
+};
+
+export default Header;


### PR DESCRIPTION
## 概要
+  headerとfooterを追加
+  suspenceとreact.lazyを用いたルーティング処理に変更